### PR TITLE
Recent audit of my original matlab codes

### DIFF
--- a/inst/m_files/rss_varbvsr.m
+++ b/inst/m_files/rss_varbvsr.m
@@ -77,9 +77,16 @@ function [lnZ, alpha, mu, s, info] = rss_varbvsr(betahat, se, SiRiS, sigb, logod
   s 		= (se_square .* sigb_square) ./ (se_square + sigb_square);
 
   % Initialize the fields of the structure info.
-  lnZ    = -Inf;
   iter   = 0;
   loglik = [];
+
+  % Calculate the variational lower bound based on the initial values.
+  r   = alpha .* mu;
+  lnZ = q'*r - 0.5*r'*SiRiSr - 0.5*(1./se_square)'*betavar(alpha, mu, s);
+  lnZ = lnZ + intgamma(logodds, alpha) + intklbeta_rssbvsr(alpha, mu, s, sigb_square);
+  fprintf('Calculate the variational lower bound based on the initial values: %+13.6e ...\n', lnZ);
+  
+  loglik = [loglik; lnZ]; %#ok<AGROW>
 
   if verbose
     fprintf('       variational    max. incl max.       \n');

--- a/inst/m_files/rss_varbvsr.m
+++ b/inst/m_files/rss_varbvsr.m
@@ -38,7 +38,6 @@ function [lnZ, alpha, mu, s, info] = rss_varbvsr(betahat, se, SiRiS, sigb, logod
   % Set initial estimates of variational parameters.
   if isfield(options,'alpha')
     alpha = double(options.alpha(:));
-    alpha = alpha / sum(alpha);
   else
     alpha = rand(p,1);
     alpha = alpha / sum(alpha);

--- a/inst/m_files/rss_varbvsr_bigmem.m
+++ b/inst/m_files/rss_varbvsr_bigmem.m
@@ -38,7 +38,6 @@ function [lnZ, alpha, mu, s, info] = rss_varbvsr_bigmem(file, sigb, logodds, opt
   % Set initial estimates of variational parameters.
   if isfield(options,'alpha')
     alpha = double(options.alpha(:));
-    alpha = alpha / sum(alpha);
   else
     alpha = rand(p,1);
     alpha = alpha / sum(alpha);

--- a/inst/m_files/rss_varbvsr_bigmem.m
+++ b/inst/m_files/rss_varbvsr_bigmem.m
@@ -100,9 +100,22 @@ function [lnZ, alpha, mu, s, info] = rss_varbvsr_bigmem(file, sigb, logodds, opt
   s = cell2mat(s_cell);
   
   % Initialize the fields of the structure info.
-  lnZ    = -Inf;
   iter   = 0;
   loglik = [];
+
+  % Calculate the variational lower bound based on the initial values.
+  parfor c = 1:C
+    r = alpha_cell{c,1} .* mu_cell{c,1};
+
+    lnZ_cell(c) = (q_cell{c,1})'*r - 0.5*r'*SiRiSr_cell{c,1} + intgamma(logodds,alpha_cell{c,1});
+    lnZ_cell(c) = lnZ_cell(c) - 0.5*(1./sesquare_cell{c,1})'*betavar(alpha_cell{c,1},mu_cell{c,1},s_cell{c,1});
+    lnZ_cell(c) = lnZ_cell(c) + intklbeta_rssbvsr(alpha_cell{c,1},mu_cell{c,1},s_cell{c,1},sigb_square);
+  end
+  lnZ = sum(lnZ_cell);
+  fprintf('Calculate the variational lower bound based on the initial values: %+13.6e ...\n', lnZ);
+
+  % Record the variational lower bound at each iteration.
+  loglik = [loglik; lnZ]; %#ok<AGROW>
 
   if verbose
     fprintf('       variational    max. incl max.       \n');

--- a/inst/m_files/rss_varbvsr_bigmem_squarem.m
+++ b/inst/m_files/rss_varbvsr_bigmem_squarem.m
@@ -106,9 +106,22 @@ function [lnZ, alpha, mu, s, info] = rss_varbvsr_bigmem_squarem(file, sigb, logo
   s = cell2mat(s_cell);
  
   % Initialize the fields of the structure info.
-  lnZ    = -Inf;
   iter   = 0;
   loglik = [];
+
+  % Calculate the variational lower bound based on the initial values.
+  parfor c = 1:C
+    r = alpha_cell{c,1} .* mu_cell{c,1};
+
+    lnZ_cell(c) = (q_cell{c,1})'*r - 0.5*r'*SiRiSr_cell{c,1} + intgamma(logodds,alpha_cell{c,1});
+    lnZ_cell(c) = lnZ_cell(c) - 0.5*(1./sesquare_cell{c,1})'*betavar(alpha_cell{c,1},mu_cell{c,1},s_cell{c,1});
+    lnZ_cell(c) = lnZ_cell(c) + intklbeta_rssbvsr(alpha_cell{c,1},mu_cell{c,1},s_cell{c,1},sigb_square);
+  end
+  lnZ = sum(lnZ_cell);
+  fprintf('Calculate the variational lower bound based on the initial values: %+13.6e ...\n', lnZ);
+
+  % Record the variational lower bound at each iteration.
+  loglik = [loglik; lnZ]; %#ok<AGROW>
 
   if verbose
     fprintf('       variational    max. incl max.       \n');

--- a/inst/m_files/rss_varbvsr_bigmem_squarem.m
+++ b/inst/m_files/rss_varbvsr_bigmem_squarem.m
@@ -45,7 +45,6 @@ function [lnZ, alpha, mu, s, info] = rss_varbvsr_bigmem_squarem(file, sigb, logo
   % Set initial estimates of variational parameters.
   if isfield(options,'alpha')
     alpha = double(options.alpha(:));
-    alpha = alpha / sum(alpha);
   else
     alpha = rand(p,1);
     alpha = alpha / sum(alpha);

--- a/inst/m_files/rss_varbvsr_parallel.m
+++ b/inst/m_files/rss_varbvsr_parallel.m
@@ -34,7 +34,6 @@ function [lnZ, alpha, mu, s, info] = rss_varbvsr_parallel(betahat, se, SiRiS, si
   % Set initial estimates of variational parameters.
   if isfield(options,'alpha')
     alpha = double(options.alpha(:));
-    alpha = alpha / sum(alpha);
   else
     alpha = rand(p,1);
     alpha = alpha / sum(alpha);

--- a/inst/m_files/rss_varbvsr_pasquarem.m
+++ b/inst/m_files/rss_varbvsr_pasquarem.m
@@ -35,7 +35,6 @@ function [lnZ, alpha, mu, s, info] = rss_varbvsr_pasquarem(betahat, se, SiRiS, s
   % Set initial estimates of variational parameters.
   if isfield(options,'alpha')
     alpha = double(options.alpha(:));
-    alpha = alpha / sum(alpha);
   else
     alpha = rand(p,1);
     alpha = alpha / sum(alpha);

--- a/inst/m_files/rss_varbvsr_pasquarem.m
+++ b/inst/m_files/rss_varbvsr_pasquarem.m
@@ -91,10 +91,23 @@ function [lnZ, alpha, mu, s, info] = rss_varbvsr_pasquarem(betahat, se, SiRiS, s
   s = cell2mat(s_cell);
  
   % Initialize the fields of the structure info.
-  lnZ    = -Inf;
   iter   = 0;
   loglik = [];
 
+  % Calculate the variational lower bound based on the initial values.
+  parfor c = 1:C
+    r = alpha_cell{c,1} .* mu_cell{c,1};
+
+    lnZ_cell(c) = (q_cell{c,1})'*r - 0.5*r'*SiRiSr_cell{c,1} + intgamma(logodds,alpha_cell{c,1});
+    lnZ_cell(c) = lnZ_cell(c) - 0.5*(1./sesquare_cell{c,1})'*betavar(alpha_cell{c,1},mu_cell{c,1},s_cell{c,1});
+    lnZ_cell(c) = lnZ_cell(c) + intklbeta_rssbvsr(alpha_cell{c,1},mu_cell{c,1},s_cell{c,1},sigb_square);
+  end
+  lnZ = sum(lnZ_cell);
+  fprintf('Calculate the variational lower bound based on the initial values: %+13.6e ...\n', lnZ);
+
+  % Record the variational lower bound at each iteration.
+  loglik = [loglik; lnZ]; %#ok<AGROW>
+ 
   if verbose
     fprintf('       variational    max. incl max.       \n');
     fprintf('iter   lower bound  change vars E[b] sigma2\n');

--- a/inst/m_files/rss_varbvsr_squarem.m
+++ b/inst/m_files/rss_varbvsr_squarem.m
@@ -85,9 +85,16 @@ function [lnZ, alpha, mu, s, info] = rss_varbvsr_squarem(betahat, se, SiRiS, sig
   s 		= (se_square .* sigb_square) ./ (se_square + sigb_square);
 
   % Initialize the fields of the structure info.
-  lnZ    = -Inf;
   iter   = 0;
   loglik = [];
+
+  % Calculate the variational lower bound based on the initial values.
+  r   = alpha .* mu;
+  lnZ = q'*r - 0.5*r'*SiRiSr - 0.5*(1./se_square)'*betavar(alpha, mu, s);
+  lnZ = lnZ + intgamma(logodds, alpha) + intklbeta_rssbvsr(alpha, mu, s, sigb_square);
+  fprintf('Calculate the variational lower bound based on the initial values: %+13.6e ...\n', lnZ);
+
+  loglik = [loglik; lnZ]; %#ok<AGROW>
 
   if verbose
     fprintf('       variational    max. incl max.       \n');

--- a/inst/m_files/rss_varbvsr_squarem.m
+++ b/inst/m_files/rss_varbvsr_squarem.m
@@ -39,7 +39,6 @@ function [lnZ, alpha, mu, s, info] = rss_varbvsr_squarem(betahat, se, SiRiS, sig
   % Set initial estimates of variational parameters.
   if isfield(options,'alpha')
     alpha = double(options.alpha(:));
-    alpha = alpha / sum(alpha);
   else
     alpha = rand(p,1);
     alpha = alpha / sum(alpha);


### PR DESCRIPTION
Hi @CreRecombinase,

Recently I have been performing (another round of) code audit of my original `Matlab` implementation of `rss_varbvsr`. No major issues were identified. However, there are two minor issues.

1. User-specified values of `alpha` are accidentally modified.

This issue corresponds to commit 0b4cd12. There was a duplicate line of code that accidentally changed the value of `alpha` provided by users. This duplicated line might be problematic if users provide a very good starting value of `alpha` (e.g. ground truth). In contrast, it is much less problematic when users provide a random starting value, which is very common in practice.   

2. The variational lower bound at initial values are not computed.

This issue corresponds to commits d9bcdca, d53572b and c637eaf. In previous versions, I did not compute the variational lower bound `lnZ` at initial values and simply assigned `-Inf` to it. The intuition is that `lnZ` at random initial values tend to be very small, especially in high-dimensional case. Similar to the issue above, this simplification does not affect the results if the initial values of `[alpha, mu]` are randomly assigned. However, this might cause problem if the initial values are well chosen (e.g. ground truth).

To address these two minor issues, I create this pull request. Please review and test it at your earliest convenience. Please let me know if there is any problem.

The main algorithm is independent of these two issues, so I speculate that neither of these issues would affect your current implementation and testing results, but I think it is important for us to fix them at an early stage of package development.    